### PR TITLE
Expand the upper limit of processor number 

### DIFF
--- a/cpuid.c
+++ b/cpuid.c
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
 		exit(127);
 	} else if (argc == 2) {
 		cpu = strtoul(argv[1], &endptr, 0);
-		if (*endptr || cpu > 255) {
+		if (*endptr || cpu > 65535) {
 			usage();
 			exit(127);
 		}

--- a/rdmsr.c
+++ b/rdmsr.c
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'p':
 			arg = strtoul(optarg, &endarg, 0);
-			if (*endarg || arg > 255) {
+			if (*endarg || arg > 65535) {
 				usage();
 				exit(127);
 			}

--- a/wrmsr.c
+++ b/wrmsr.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'p':
 			arg = strtoul(optarg, &endarg, 0);
-			if (*endarg || arg > 255) {
+			if (*endarg || arg > 65535) {
 				usage();
 				exit(127);
 			}


### PR DESCRIPTION
Increase the maximum processor number specified by -p option from 255 to 65535.
Nowadays there exist boxes that have over 256 processors.

Signed-off-by: Seiichi Ikarashi s.ikarashi@jp.fujitsu.com
