### PR TITLE
Expand the upper limit of processor number from 255

### DIFF
--- a/cpuid.c
+++ b/cpuid.c
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
 		exit(127);
 	} else if (argc == 2) {
 		cpu = strtoul(argv[1], &endptr, 0);
-		if (*endptr || cpu > 255) {
+		if (*endptr || cpu > 5119) {
 			usage();
 			exit(127);
 		}

--- a/rdmsr.c
+++ b/rdmsr.c
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'p':
 			arg = strtoul(optarg, &endarg, 0);
-			if (*endarg || arg > 255) {
+			if (*endarg || arg > 5119) {
 				usage();
 				exit(127);
 			}

--- a/wrmsr.c
+++ b/wrmsr.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'p':
 			arg = strtoul(optarg, &endarg, 0);
-			if (*endarg || arg > 255) {
+			if (*endarg || arg > 5119) {
 				usage();
 				exit(127);
 			}


### PR DESCRIPTION
Nowadays, over-256 processor systems are coming.
Let's expand the max limit of processor number at least
to the theoretical max logical CPUs of RHEL7, 5120.
