### PR TITLE
Change name of cpuid tools to msr-cpuid

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 AM_CFLAGS = -Wall -g -O2 -fomit-frame-pointer \
 	-D_GNU_SOURCE -D_FILE_OFFSET_BITS=64
 
-bin_PROGRAMS = wrmsr rdmsr cpuid
+bin_PROGRAMS = wrmsr rdmsr msr-cpuid
 
 wrmsr_SOURCES =		\
 	wrmsr.c		\
@@ -15,7 +15,7 @@ rdmsr_SOURCES =		\
 
 rdmsr_CFLAGS = $(AM_CFLAGS)
 
-cpuid_SOURCES =		\
+msr_cpuid_SOURCES =		\
 	cpuid.c
 
-cpuid_CFLAGS = $(AM_CFLAGS)
+msr_cpuid_CFLAGS = $(AM_CFLAGS)


### PR DESCRIPTION
This change is necesary sinc ethe name has conflicts with other open
sourse projects already installed in the operating system:

http://pkgs.fedoraproject.org/cgit/rpms/cpuid.git/tree/cpuid.spec

Even RH cahnge the name of the binary to avoid conlficts:

http://pkgs.fedoraproject.org/cgit/rpms/msr-tools.git/tree/msr-tools.spec

install -D cpuid %{buildroot}%{_sbindir}/msr-cpuid

Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>