### PR TITLE
Fail to read/write if register number is not parsed correctly

### DIFF
--- a/rdmsr.c
+++ b/rdmsr.c
@@ -194,7 +194,11 @@ int main(int argc, char *argv[])
 		exit(127);
 	}
 
-	reg = strtoul(argv[optind], NULL, 0);
+	reg = strtoul(argv[optind], &endarg, 0);
+	if (*endarg) {
+		printf("Failed to parse register number. Do you need a prefix?\n");
+		exit(127);
+	}
 
 	if (cpu == -1) {
 		doing_for_all = 1;

--- a/wrmsr.c
+++ b/wrmsr.c
@@ -121,7 +121,11 @@ int main(int argc, char *argv[])
 		exit(127);
 	}
 
-	reg = strtoul(argv[optind++], NULL, 0);
+	reg = strtoul(argv[optind++], &endarg, 0);
+	if (*endarg) {
+		printf("Failed to parse register number. Do you need a prefix?\n");
+		exit(127);
+	}
 
 	if (cpu == -1) {
 		doing_for_all = 1;


### PR DESCRIPTION
It's possible that a user will provide a register number in a format
that strtoul() can't parse. strtoul() will return 0 if it fails to parse
a value. The msr-tools will then silently read/write to MSR 0x0 and
succeed. At best this may confuse the user, or at worst this will
unintentionally write bad data to the system.

Check that the register number parsing has succeeded. If it fails, then
inform the user, give a suggestion, and exit.

Signed-off-by: Yazen Ghannam <yazen.ghannam@amd.com>