### PR TITLE
Register number parse fix

### DIFF
--- a/rdmsr.c
+++ b/rdmsr.c
@@ -194,7 +194,11 @@ int main(int argc, char *argv[])
 		exit(127);
 	}
 
-	reg = strtoul(argv[optind], NULL, 0);
+	reg = strtoul(argv[optind], &endarg, 0);
+	if (*endarg) {
+		printf("Failed to parse register number. Do you need a prefix?\n");
+		exit(127);
+	}
 
 	if (cpu == -1) {
 		doing_for_all = 1;

--- a/rdmsr.c
+++ b/rdmsr.c
@@ -196,7 +196,7 @@ int main(int argc, char *argv[])
 
 	reg = strtoul(argv[optind], &endarg, 0);
 	if (*endarg) {
-		printf("Failed to parse register number. Do you need a prefix?\n");
+		fprintf(stderr, "rdmsr: failed to parse register number\n");
 		exit(127);
 	}
 

--- a/wrmsr.c
+++ b/wrmsr.c
@@ -121,7 +121,11 @@ int main(int argc, char *argv[])
 		exit(127);
 	}
 
-	reg = strtoul(argv[optind++], NULL, 0);
+	reg = strtoul(argv[optind++], &endarg, 0);
+	if (*endarg) {
+		printf("Failed to parse register number. Do you need a prefix?\n");
+		exit(127);
+	}
 
 	if (cpu == -1) {
 		doing_for_all = 1;

--- a/wrmsr.c
+++ b/wrmsr.c
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
 
 	reg = strtoul(argv[optind++], &endarg, 0);
 	if (*endarg) {
-		printf("Failed to parse register number. Do you need a prefix?\n");
+		fprintf(stderr, "wrmsr: failed to parse register number\n");
 		exit(127);
 	}
 


### PR DESCRIPTION
As reported in issue #8 , rdmsr and wrmsr will silently mis-parse register numbers in a string format
that strtoul() doesn't understand. Pull request #12 fixes this, but the error message is not great.

This pull request includes Yazen's fix for #8 , but also updates the error messages to go to the right place (stderr) and to be more terse and also match the format of other error strings in the tools.