### PR TITLE
Change installation directory back to historical location

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,7 @@ AM_CFLAGS = -Wall -g -O2 -fomit-frame-pointer \
 	-D_GNU_SOURCE -D_FILE_OFFSET_BITS=64
 
 bin_PROGRAMS = wrmsr rdmsr msr-cpuid
+man8_MANS = wrmsr.8 rdmsr.8 msr-cpuid.8
 
 wrmsr_SOURCES =		\
 	wrmsr.c		\

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 AM_CFLAGS = -Wall -g -O2 -fomit-frame-pointer \
 	-D_GNU_SOURCE -D_FILE_OFFSET_BITS=64
 
-bin_PROGRAMS = wrmsr rdmsr msr-cpuid
+sbin_PROGRAMS = wrmsr rdmsr msr-cpuid
 man8_MANS = wrmsr.8 rdmsr.8 msr-cpuid.8
 
 wrmsr_SOURCES =		\

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_MSG_RESULT([
         ========
 
         prefix:                 ${prefix}
-        bindir:                 ${bindir}
+        sbindir:                ${sbindir}
 
         compiler:               ${CC}
         cflags:                 ${CFLAGS}

--- a/msr-cpuid.8
+++ b/msr-cpuid.8
@@ -1,0 +1,27 @@
+.\"
+.\" msr-cpuid(8)
+.\"
+.\" Copyright (C) 2013 Andres Salomon
+.TH msr-cpuid 8 "Oct 2013"
+.SH NAME
+msr-cpuid \- tool for reading CPUIDs from x86 processors
+.SH SYNOPSIS
+.B "msr-cpuid [processor # (default 0)]"
+.SH DESCRIPTION
+.B msr-cpuid
+is a tool used for reading a processor's CPUID.
+.br
+Note: if you're running a Debian kernel, be sure that the cpuid.ko kernel
+module is loaded. 'modprobe cpuid' should do the trick. Otherwise, you'll
+get an error about
+.B msr-cpuid
+not being able to open files in /dev/cpu/...
+.BR
+.SH AUTHOR
+.br
+.B msr-cpuid
+was written by Intel
+
+This man page was contributed by Andres Salomon <dilinger@debian.org>
+for the Debian GNU/Linux system (but may be used by others).
+

--- a/rdmsr.8
+++ b/rdmsr.8
@@ -1,0 +1,73 @@
+.\"
+.\" rdmsr(8)
+.\"
+.\" Copyright (C) 2008 Andres Salomon
+.TH rdmsr 8 "Mar 2008"
+.SH NAME
+rdmsr \- tool for reading CPU machine specific registers (MSR)
+.SH SYNOPSIS
+.B "rdmsr [options] regno"
+.SH DESCRIPTION
+.B rdmsr
+is a tool used for reading a CPU's machine specific registers (MSR).
+.br
+Note: if you're running a distribution kernel, be sure that the msr.ko kernel
+module is loaded. 'modprobe msr' should do the trick. Otherwise, you'll
+get an error about
+.B rdmsr
+not being able to open files in /dev/cpu/...
+.SH OPTIONS
+.TP
+.B --help,          -h
+Print a list of available options
+.TP
+.B --version,       -V
+Print current version
+.TP
+.B --hexadecimal,   -x
+Display output in hexadecimal (lower case)
+.TP
+.B --capital-hex,   -X
+Display output in hexadecimal (upper case)
+.TP
+.B --decimal,       -d
+Display output in signed decimal
+.TP
+.B --unsigned,      -u
+Display output in unsigned decimal
+.TP
+.B --octal,         -o
+Display output in octal
+.TP
+.B --c-language,    -c
+Format output as a C language constant
+.TP
+.B --zero-pad,      -0
+Output leading zeroes
+.TP
+.B --zero-pad,      -0
+Output leading zeroes
+.TP
+.B --raw,           -r
+Output raw binary
+.TP
+.B --all,           -a
+All processors
+.TP
+.B --processor <#>, -p
+Select processor number (default: 0)
+.TP
+.B --bitfield h:l, -f
+Output bits [h:l] only
+.TP
+.BR
+.SH SEE ALSO
+.BR wrmsr(8)
+.SH AUTHOR
+.br
+.B rdmsr
+was written by Transmeta Corporation
+
+This man page was contributed by Andres Salomon <dilinger@debian.org>
+for the Debian GNU/Linux system (but may be used by others).
+

--- a/wrmsr.8
+++ b/wrmsr.8
@@ -1,0 +1,43 @@
+.\"
+.\" wrmsr(8)
+.\"
+.\" Copyright (C) 2008 Andres Salomon
+.TH wrmsr 8 "Mar 2008"
+.SH NAME
+wrmsr \- tool for writing CPU machine specific registers (MSR)
+.SH SYNOPSIS
+.B "wrmsr [options] regno value"
+.SH DESCRIPTION
+.B wrmsr
+is a tool used for writing values to a CPU's machine specific registers (MSR).
+.br
+Note: if you're running a distribution kernel, be sure that the msr.ko kernel
+module is loaded. 'modprobe msr' should do the trick. Otherwise, you'll
+get an error about
+.B wrmsr
+not being able to open files in /dev/cpu/...
+.SH OPTIONS
+.TP
+.B --help,          -h
+Print a list of available options
+.TP
+.B --version,       -V
+Print current version
+.TP
+.B --all,           -a
+All processors
+.TP
+.B --processor <#>, -p
+Select processor number (default: 0)
+.TP
+.BR
+.SH SEE ALSO
+.BR rdmsr(8)
+.SH AUTHOR
+.br
+.B wrmsr
+was written by Transmeta Corporation
+
+This man page was contributed by Andres Salomon <dilinger@debian.org>
+for the Debian GNU/Linux system (but may be used by others).
+


### PR DESCRIPTION
Older versions of msr-tools had the following Makefile snippets:
    
sbindir = /usr/sbin
    
install: all
            install -m 755 $(BIN) $(sbindir)
    
That's (in my opinion, at least) the proper location for these tools.
They require superuser privileges, and are tickling CPU registers. Thus,
they belong in /usr/sbin along with other administration utilities.
    
However, when msr-tools switched to using autotools, the installation
directory changed to /usr/bin. This patch changes it back to installing
into /usr/sbin.